### PR TITLE
Use custom gesture recognizer instead of UIPanGestureRecognizer

### DIFF
--- a/Drawsana.xcodeproj/project.pbxproj
+++ b/Drawsana.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3706B15A211B972A00D41622 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 3706B159211B972A00D41622 /* LICENSE */; };
 		3706B15C211BA07F00D41622 /* KeyedDecodingContainer+DrawsanaExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706B15B211BA07F00D41622 /* KeyedDecodingContainer+DrawsanaExtensions.swift */; };
 		3706B15E211CF29500D41622 /* DrawingToolForShapeWithTwoPoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3706B15D211CF29500D41622 /* DrawingToolForShapeWithTwoPoints.swift */; };
+		371BE7D02123643100861596 /* ImmediatePanGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371BE7CF2123643100861596 /* ImmediatePanGestureRecognizer.swift */; };
 		37362D5C21151684003E5ACA /* TextShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37362D5B21151684003E5ACA /* TextShape.swift */; };
 		37362D5E2118D8A3003E5ACA /* ToolSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37362D5D2118D8A3003E5ACA /* ToolSettings.swift */; };
 		37362D602118E46F003E5ACA /* DrawingOperationStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37362D5F2118E46F003E5ACA /* DrawingOperationStack.swift */; };
@@ -83,6 +84,7 @@
 		3706B159211B972A00D41622 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		3706B15B211BA07F00D41622 /* KeyedDecodingContainer+DrawsanaExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+DrawsanaExtensions.swift"; sourceTree = "<group>"; };
 		3706B15D211CF29500D41622 /* DrawingToolForShapeWithTwoPoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingToolForShapeWithTwoPoints.swift; sourceTree = "<group>"; };
+		371BE7CF2123643100861596 /* ImmediatePanGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmediatePanGestureRecognizer.swift; sourceTree = "<group>"; };
 		37362D5B21151684003E5ACA /* TextShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextShape.swift; sourceTree = "<group>"; };
 		37362D5D2118D8A3003E5ACA /* ToolSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolSettings.swift; sourceTree = "<group>"; };
 		37362D5F2118E46F003E5ACA /* DrawingOperationStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingOperationStack.swift; sourceTree = "<group>"; };
@@ -231,6 +233,7 @@
 			isa = PBXGroup;
 			children = (
 				3762296D2113A9E60034D0E3 /* DrawsanaUtilities.swift */,
+				371BE7CF2123643100861596 /* ImmediatePanGestureRecognizer.swift */,
 				37362D72211B853B003E5ACA /* Extensions */,
 			);
 			path = Helpers;
@@ -477,6 +480,7 @@
 				3777F2FD21068A5C009A9AC5 /* Shape.swift in Sources */,
 				37885E2C210A9C95003A918F /* PenTool_EraserTool.swift in Sources */,
 				37362D5C21151684003E5ACA /* TextShape.swift in Sources */,
+				371BE7D02123643100861596 /* ImmediatePanGestureRecognizer.swift in Sources */,
 				376229832113AD6E0034D0E3 /* Drawing.swift in Sources */,
 				37362D71211B7386003E5ACA /* TextShapeEditingView.swift in Sources */,
 			);

--- a/Drawsana/Helpers/ImmediatePanGestureRecognizer.swift
+++ b/Drawsana/Helpers/ImmediatePanGestureRecognizer.swift
@@ -9,6 +9,23 @@
 import UIKit
 import UIKit.UIGestureRecognizerSubclass
 
+/**
+ Replaces a tap gesture recognizer and a pan gesture recognizer with just one
+ gesture recognizer.
+
+ Lifecycle:
+ * Touch begins, state -> .began (all other touches are completely ignored)
+ * Touch moves, state -> .changed
+ * Touch ends
+   * If touch moved more than 10px away from the origin at some point, then
+     `hasExceededTapThreshold` was set to `true`. Target may use this to
+     distinguish a pan from a tap when the gesture has ended and act
+     accordingly.
+
+ This behavior is better than using a regular UIPanGestureRecognizer because
+ that class ignores the first ~20px of the touch while it figures out if you
+ "really" want to pan. This is a drawing program, so that's not good.
+ */
 class ImmediatePanGestureRecognizer: UIGestureRecognizer {
   var tapThreshold: CGFloat = 10
   // If gesture ends and this value is `true`, then the user's finger moved
@@ -30,7 +47,10 @@ class ImmediatePanGestureRecognizer: UIGestureRecognizer {
   }
 
   override func location(in view: UIView?) -> CGPoint {
-    return lastPoint
+    guard let view = view else {
+      return lastPoint
+    }
+    return view.convert(lastPoint, to: view)
   }
 
   override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {

--- a/Drawsana/Helpers/ImmediatePanGestureRecognizer.swift
+++ b/Drawsana/Helpers/ImmediatePanGestureRecognizer.swift
@@ -1,0 +1,89 @@
+//
+//  ImmediatePanGestureRecognizer.swift
+//  Drawsana
+//
+//  Created by Steve Landey on 8/14/18.
+//  Copyright © 2018 Asana. All rights reserved.
+//
+
+import UIKit
+import UIKit.UIGestureRecognizerSubclass
+
+class ImmediatePanGestureRecognizer: UIGestureRecognizer {
+  var tapThreshold: CGFloat = 10
+  // If gesture ends and this value is `true`, then the user's finger moved
+  // more than `tapThreshold` points during the gesture, i.e. it is not a tap.
+  var hasExceededTapThreshold = false
+
+  private var startPoint: CGPoint = .zero
+  private var lastLastPoint: CGPoint = .zero
+  private var lastLastTime: CFTimeInterval = 0
+  private var lastPoint: CGPoint = .zero
+  private var lastTime: CFTimeInterval = 0
+  private var trackedTouch: UITouch?
+
+  var velocity: CGPoint? {
+    guard let view = view, let trackedTouch = trackedTouch else { return nil }
+    let delta = trackedTouch.location(in: view) - lastLastPoint
+    let deltaT = CGFloat(lastTime - lastLastTime)
+    return CGPoint(x: delta.x / deltaT , y: delta.y - deltaT)
+  }
+
+  override func location(in view: UIView?) -> CGPoint {
+    return lastPoint
+  }
+
+  override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+    guard trackedTouch == nil, let firstTouch = touches.first, let view = view else { return }
+    trackedTouch = firstTouch
+    startPoint = firstTouch.location(in: view)
+    lastPoint = startPoint
+    lastTime = CFAbsoluteTimeGetCurrent()
+    lastLastPoint = startPoint
+    lastLastTime = lastTime
+    state = .began
+  }
+
+  override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent) {
+    guard
+      state == .began || state == .changed,
+      let view = view,
+      let trackedTouch = trackedTouch,
+      touches.contains(trackedTouch) else
+    {
+      return
+    }
+
+    lastLastTime = lastTime
+    lastLastPoint = lastPoint
+    lastTime = CFAbsoluteTimeGetCurrent()
+    lastPoint = trackedTouch.location(in: view)
+    if (lastPoint - startPoint).length >= tapThreshold {
+      hasExceededTapThreshold = true
+    }
+
+    state = .changed
+  }
+
+  override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+    guard
+      state == .began || state == .changed,
+      let trackedTouch = trackedTouch,
+      touches.contains(trackedTouch) else
+    {
+      return
+    }
+
+    state = .ended
+
+    DispatchQueue.main.async {
+      self.reset()
+    }
+  }
+
+  override func reset() {
+    super.reset()
+    trackedTouch = nil
+    hasExceededTapThreshold = false
+  }
+}

--- a/Drawsana/Helpers/ImmediatePanGestureRecognizer.swift
+++ b/Drawsana/Helpers/ImmediatePanGestureRecognizer.swift
@@ -30,7 +30,7 @@ class ImmediatePanGestureRecognizer: UIGestureRecognizer {
   var tapThreshold: CGFloat = 10
   // If gesture ends and this value is `true`, then the user's finger moved
   // more than `tapThreshold` points during the gesture, i.e. it is not a tap.
-  var hasExceededTapThreshold = false
+  private(set) var hasExceededTapThreshold = false
 
   private var startPoint: CGPoint = .zero
   private var lastLastPoint: CGPoint = .zero

--- a/Drawsana/Shapes/Implementations/PenShape.swift
+++ b/Drawsana/Shapes/Implementations/PenShape.swift
@@ -103,25 +103,37 @@ public class PenShape: Shape, ShapeWithStrokeState {
     }
     var lastWidth = segments[0].width
     var hasStroked = false // make sure we finally stroke the path
-    for segment in (onlyLast ? [segments.last!] : segments) {
+    for (i, segment) in (onlyLast ? [segments.last!] : segments).enumerated() {
       hasStroked = false
-      context.setLineWidth(segment.width)
       let needsStroke = segment.width != lastWidth
+      context.setLineWidth(segment.width)
       if let previousMid = lastSegment?.midPoint {
         let currentMid = segment.midPoint
         context.move(to: previousMid)
         context.addQuadCurve(to: currentMid, control: segment.a)
-      } else {
+        // Usually we only draw up to the mid point of the segment, but if the
+        // shape is done and this is the last segment, go ahead and draw a line
+        // to the end
+        if i == segments.count - 1 && isFinished {
+          context.addLine(to: segment.b)
+        }
+      } else if segments.count == 1 {
         context.move(to: segment.a)
         context.addLine(to: segment.b)
+      } else {
+        context.move(to: segment.a)
+        context.addLine(to: segment.midPoint)
       }
+
       if needsStroke {
         context.strokePath()
         hasStroked = true
       }
+
       lastWidth = segment.width
       lastSegment = segment
     }
+
     if !hasStroked {
       context.strokePath()
     }

--- a/Drawsana/Tools/Implementations/DrawingToolForShapeWithTwoPoints.swift
+++ b/Drawsana/Tools/Implementations/DrawingToolForShapeWithTwoPoints.swift
@@ -55,7 +55,9 @@ public class DrawingToolForShapeWithTwoPoints: DrawingTool {
   }
 
   public func handleDragCancel(context: ToolOperationContext, point: CGPoint) {
-    shapeInProgress = nil
+    // No such thing as a cancel for this tool. If this was recognized as a tap,
+    // just end the shape normally.
+    handleDragEnd(context: context, point: point)
   }
 
   public func renderShapeInProgress(transientContext: CGContext) {

--- a/Drawsana/Tools/Implementations/PenTool_EraserTool.swift
+++ b/Drawsana/Tools/Implementations/PenTool_EraserTool.swift
@@ -14,7 +14,7 @@ public class PenTool: DrawingTool {
   public var name: String { return "Pen" }
   public var shapeInProgress: PenShape?
   public var isProgressive: Bool { return false }
-  public var velocityBasedWidth: Bool = true
+  public var velocityBasedWidth: Bool = false
 
   private var lastVelocity: CGPoint = .zero
   // The shape is rendered to a buffer so that if the color is transparent,
@@ -42,6 +42,7 @@ public class PenTool: DrawingTool {
     let shape = PenShape()
     shapeInProgress = shape
     shape.start = point
+    shape.isFinished = false
     shape.apply(userSettings: context.userSettings)
     shape.strokeColor = shape.strokeColor.withAlphaComponent(1)
   }
@@ -60,7 +61,9 @@ public class PenTool: DrawingTool {
     } else {
       segmentWidth = shape.strokeWidth
     }
-    shape.add(segment: PenLineSegment(a: lastPoint, b: point, width: segmentWidth))
+    if lastPoint != point {
+      shape.add(segment: PenLineSegment(a: lastPoint, b: point, width: segmentWidth))
+    }
     lastVelocity = velocity
   }
 
@@ -74,8 +77,9 @@ public class PenTool: DrawingTool {
   }
 
   public func handleDragCancel(context: ToolOperationContext, point: CGPoint) {
-    shapeInProgress = nil
-    shapeInProgressBuffer = nil
+    // No such thing as a cancel for this tool. If this was recognized as a tap,
+    // just end the shape normally.
+    handleDragEnd(context: context, point: point)
   }
 
   public func renderShapeInProgress(transientContext: CGContext) {

--- a/Drawsana/Tools/Implementations/SelectionTool.swift
+++ b/Drawsana/Tools/Implementations/SelectionTool.swift
@@ -27,6 +27,18 @@ public class SelectionTool: DrawingTool {
 
   private var originalTransform: ShapeTransform?
   private var startPoint: CGPoint?
+  /* When you tap away from a shape you've just dragged, the method calls look
+     like this:
+      - handleDragStart (hitTest on selectedShape fails)
+      - handleDragContinue
+      - handleDragCancel
+      - handleTap
+
+     We need to be careful not to incorrectly reset the transform for the selected
+     shape when you tap away, so we explicitly capture whether you are actually
+     dragging the shape or not.
+   */
+  private var isDraggingShape = false
 
   public init(delegate: SelectionToolDelegate? = nil) {
     self.delegate = delegate
@@ -61,17 +73,23 @@ public class SelectionTool: DrawingTool {
   }
 
   public func handleDragStart(context: ToolOperationContext, point: CGPoint) {
-    guard let selectedShape = context.toolSettings.selectedShape, selectedShape.hitTest(point: point) else { return }
+    guard let selectedShape = context.toolSettings.selectedShape, selectedShape.hitTest(point: point) else {
+      isDraggingShape = false
+      return
+    }
+    isDraggingShape = true
     originalTransform = selectedShape.transform
     startPoint = point
   }
 
   public func handleDragContinue(context: ToolOperationContext, point: CGPoint, velocity: CGPoint) {
     guard
+      isDraggingShape,
       let originalTransform = originalTransform,
       let selectedShape = context.toolSettings.selectedShape,
       let startPoint = startPoint else
     {
+      isDraggingShape = false
         return
     }
     let delta = CGPoint(x: point.x - startPoint.x, y: point.y - startPoint.y)
@@ -81,10 +99,12 @@ public class SelectionTool: DrawingTool {
 
   public func handleDragEnd(context: ToolOperationContext, point: CGPoint) {
     guard
+      isDraggingShape,
       let originalTransform = originalTransform,
       let selectedShape = context.toolSettings.selectedShape,
       let startPoint = startPoint else
     {
+      isDraggingShape = false
       return
     }
     let delta = CGPoint(x: point.x - startPoint.x, y: point.y - startPoint.y)
@@ -93,9 +113,11 @@ public class SelectionTool: DrawingTool {
       transform: originalTransform.translated(by: delta),
       originalTransform: originalTransform))
     context.toolSettings.isPersistentBufferDirty = true
+    isDraggingShape = false
   }
 
   public func handleDragCancel(context: ToolOperationContext, point: CGPoint) {
+    guard isDraggingShape else { return }
     context.toolSettings.selectedShape?.transform = originalTransform ?? .identity
     context.toolSettings.isPersistentBufferDirty = true
   }

--- a/Drawsana/Tools/Implementations/SelectionTool.swift
+++ b/Drawsana/Tools/Implementations/SelectionTool.swift
@@ -90,7 +90,7 @@ public class SelectionTool: DrawingTool {
       let startPoint = startPoint else
     {
       isDraggingShape = false
-        return
+      return
     }
     let delta = CGPoint(x: point.x - startPoint.x, y: point.y - startPoint.y)
     selectedShape.transform = originalTransform.translated(by: delta)


### PR DESCRIPTION
This change fixes several bugs:

* Pen tool would ignore the first ~30px of your touch
* Pen shapes would have lower line segment resolution for the first ~30 px even after starting
* Pen shapes would overdraw their first line segment, and underdraw their last line segment
* Text handles would sometimes fail to recognize drags that started on the handles
* Disable velocity based width by default, since it's basically experimental

The solution is to  replace UIPanGestureRecognizer with our own custom internal implementation that simply tracks raw touch points without trying to do anything fancy. When the touch has ended, DrawsanaView checks whether the touch moved more than 10px, and if it did, it cancels the pan on the tool and instead calls it a tap.